### PR TITLE
Corrige URL default do websocket

### DIFF
--- a/frontend/src/apis/bloquinho/bloquinho-api.ts
+++ b/frontend/src/apis/bloquinho/bloquinho-api.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 import { Extension } from '../../utils/constants/extensions';
 
-export const webSocketURL = import.meta.env.VITE_WEB_SOCKET_URL ?? 'http://localhost:8080/ws';
+export const webSocketURL = import.meta.env.VITE_WEB_SOCKET_URL ?? 'ws://localhost:8080/ws';
 
 export const bloquinhoApi = axios.create({
 	baseURL: import.meta.env.VITE_API_URL ?? 'http://localhost:8080/',


### PR DESCRIPTION
Ao usar o valor default da URL de websocket tínhamos o seguinte erro por conta de malformação da URL, essa PR o corrige:

![image](https://github.com/nidib/bloquinho/assets/70375202/dc3560cf-d2f1-4f7e-b6bd-7a0c2e06f7b4)
