### PR TITLE
infra(app): manual deploy on release

### DIFF
--- a/.github/workflows/app-ci-cd.yml
+++ b/.github/workflows/app-ci-cd.yml
@@ -7,6 +7,8 @@ on:
             - '.github/**'
             - 'app/**'
         branches: ['main']
+    release:
+        types: [published, edited]
     workflow_dispatch:
 
 jobs:
@@ -30,3 +32,16 @@ jobs:
               run: npm run lint
             - name: Compile TypeScript
               run: npm run compile
+
+    deploy:
+        needs: compile
+        runs-on: ubuntu-latest
+        if: github.event_name == 'release'
+
+        steps:
+            - uses: actions/checkout@v4
+            - name: Deploy
+              env:
+                  DEPLOY_URL: ${{ secrets.DEPLOY_URL }}
+              run: |
+                  curl -X POST "$DEPLOY_URL"


### PR DESCRIPTION
### Description
This will make the deploy to prod only happen on releasing a new version, instead of deploying on every push to main